### PR TITLE
Fix path to Chromium.app under IntelliJ caveats

### DIFF
--- a/dartium.rb
+++ b/dartium.rb
@@ -29,7 +29,7 @@ class Dartium < Formula
 
   def caveats; <<-EOS.undent
      To use with IntelliJ, set the Dartium execute home to:
-        #{prefix}/Chromium
+        #{prefix}/Chromium.app
     EOS
   end
 


### PR DESCRIPTION
The listed path to Dartium was incorrect under the IntelliJ caveats. It should be suffixed with `.app`.
