### PR TITLE
Use exec when starting process in shim script

### DIFF
--- a/dartium.rb
+++ b/dartium.rb
@@ -28,7 +28,7 @@ class Dartium < Formula
   def shim_script target
     <<-EOS.undent
       #!/bin/bash
-      "#{prefix}/#{target}" "$@"
+      exec "#{prefix}/#{target}" "$@"
     EOS
   end
 


### PR DESCRIPTION
Using `exec` will replace the shell process with the process being invoked in the shim script. This is to fix an issue where killing the shim script doesn't kill the `dartium` or `content_shell` process it started.

See dart-lang/test#101 for more info.