### PR TITLE
Flag --with-dartium should install dartium

### DIFF
--- a/dart.rb
+++ b/dart.rb
@@ -55,7 +55,7 @@ class Dart < Formula
     bin.install_symlink "#{libexec}/bin/dart"
     bin.write_exec_script Dir["#{libexec}/bin/{pub,docgen,dart?*}"]
 
-    if build.with? 'content-shell'
+    if build.with? 'dartium'
       dartium_binary = 'Chromium.app/Contents/MacOS/Chromium'
       prefix.install resource('dartium')
       (bin+"dartium").write shim_script dartium_binary


### PR DESCRIPTION
Although the `--with-dartium` flag is document, the `--with-content-shell` flag is used to include dartium in the build.