### PR TITLE
Versioned 1.x and 2.x formulae for Dart 2 migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # Dart for Homebrew
 
-This is the official [Dart][] tap for [homebrew][].
+This is the official [Dart][] tap for [Homebrew][].
 
 Mac users can use these formulae to easily install and update Dart SDK and
 Dartium. Both dev and stable channels are supported.
 
 ## Initial setup
 
-If you don't have homebrew, install it from their [homepage][homebrew].
+If you don't have Homebrew, install it from their [homepage][homebrew].
 
 Then, add this tap:
 
@@ -56,5 +56,14 @@ brew update
 brew upgrade dart
 ```
 
-[homebrew]: http://brew.sh/
+## Dart 2 Migration
+
+This tap provides versioned `dart@1` and `dart@2` formulae to assist with the migration to the new major Dart 2 release.
+
+Use `dart@2` in your formula dependencies if you are an application developer and your current version requires Dart 2. Note that this is a temporary measure; once a stable Dart 2.x release is out, the `dart@2` formula will be removed and you can go back to using the regular `dart` dependency.
+
+Use `dart@1` in formulae for legacy applications which are not compatible with Dart 2.
+
+
+[Homebrew]: http://brew.sh/
 [dart]: https://www.dartlang.org

--- a/dart@1.rb
+++ b/dart@1.rb
@@ -1,0 +1,71 @@
+class DartAT1 < Formula
+  desc "The Dart 1 SDK"
+  homepage "https://www.dartlang.org/"
+  version "1.24.3"
+
+  keg_only :versioned_formula
+
+  if MacOS.prefer_64_bit?
+    url "https://storage.googleapis.com/dart-archive/channels/stable/release/1.24.3/sdk/dartsdk-macos-x64-release.zip"
+    sha256 "3419869401184d1ebf44e8947de36ac83ff614097c2c52a80792e89a25c18cd8"
+  else
+    url "https://storage.googleapis.com/dart-archive/channels/stable/release/1.24.3/sdk/dartsdk-macos-ia32-release.zip"
+    sha256 "387fb5e1a1231b219a599d2d7efe250387e041d6b4822ec1ddbf364794762097"
+  end
+
+  option "with-content-shell", "Download and install content_shell -- headless Dartium for testing"
+  option "with-dartium", "Download and install Dartium -- Chromium with Dart"
+
+  resource "content_shell" do
+    version "1.24.3"
+    url "https://storage.googleapis.com/dart-archive/channels/stable/release/1.24.3/dartium/content_shell-macos-x64-release.zip"
+    sha256 "01efc473c68aed830307d1dafb0cbcbfe77f40ceeeab3ef3ebe58a9912d05b13"
+  end
+
+  resource "dartium" do
+    version "1.24.3"
+    url "https://storage.googleapis.com/dart-archive/channels/stable/release/1.24.3/dartium/dartium-macos-x64-release.zip"
+    sha256 "188a038bd6367fddb434338bf6549bae25f5ad89b2f5b462acf8fb1fa20a3916"
+  end
+
+  def install
+    libexec.install Dir["*"]
+    bin.install_symlink "#{libexec}/bin/dart"
+    bin.write_exec_script Dir["#{libexec}/bin/{pub,dart?*}"]
+
+    if build.with? "dartium"
+      dartium_binary = "Chromium.app/Contents/MacOS/Chromium"
+      prefix.install resource("dartium")
+      (bin+"dartium").write shim_script dartium_binary
+    end
+
+    if build.with? "content-shell"
+      content_shell_binary = "Content Shell.app/Contents/MacOS/Content Shell"
+      prefix.install resource("content_shell")
+      (bin+"content_shell").write shim_script content_shell_binary
+    end
+  end
+
+  def shim_script(target)
+    <<~EOS
+      #!/usr/bin/env bash
+      exec "#{prefix}/#{target}" "$@"
+    EOS
+  end
+
+  def caveats; <<~EOS
+    Please note the path to the Dart SDK:
+      #{opt_libexec}
+    EOS
+  end
+
+  test do
+    (testpath/"sample.dart").write <<~EOS
+      void main() {
+        print(r"test message");
+      }
+    EOS
+
+    assert_equal "test message\n", shell_output("#{bin}/dart sample.dart")
+  end
+end

--- a/dart@2.rb
+++ b/dart@2.rb
@@ -1,0 +1,46 @@
+class DartAT2 < Formula
+  desc "The Dart 2 SDK"
+  homepage "https://www.dartlang.org/"
+  version "2.0.0-dev.59.0"
+
+  keg_only :versioned_formula
+
+  if MacOS.prefer_64_bit?
+    url "https://storage.googleapis.com/dart-archive/channels/dev/release/2.0.0-dev.59.0/sdk/dartsdk-macos-x64-release.zip"
+    sha256 "dfd929ed8b07278247b041d7573d5bb966033030c9c0122dee6b0eb0b6515850"
+  else
+    url "https://storage.googleapis.com/dart-archive/channels/dev/release/2.0.0-dev.59.0/sdk/dartsdk-macos-ia32-release.zip"
+    sha256 "3fc86c5f5e88b9f652364b33de547abf6e59033a35931eb63e0c89349f64c466"
+  end
+
+  def install
+    libexec.install Dir["*"]
+    bin.install_symlink "#{libexec}/bin/dart"
+    bin.write_exec_script Dir["#{libexec}/bin/{pub,dart?*}"]
+  end
+
+  def shim_script(target)
+    <<~EOS
+      #!/usr/bin/env bash
+      exec "#{prefix}/#{target}" "$@"
+    EOS
+  end
+
+  def caveats; <<~EOS
+    Note that this is a prerelease version of Dart.
+
+    Please note the path to the Dart SDK:
+      #{opt_libexec}
+    EOS
+  end
+
+  test do
+    (testpath/"sample.dart").write <<~EOS
+      void main() {
+        print(r"test message");
+      }
+    EOS
+
+    assert_equal "test message\n", shell_output("#{bin}/dart sample.dart")
+  end
+end


### PR DESCRIPTION
You may wish to provided versioned `dart@1` and `dart@2` formulae to ease the migration to the new major-version Dart 2 release.

This PR is just an example of how you could do it; I'm new to this project so I'm not sure if it fits in with your style and workflow.

The `dart@2` formula would be a short-term one, kept around only until a stable Dart 2 release is out as the `stable` version in the main `dart` formula. This would support:
* Developers who need to depend on Dart 2 with their current development versions. Homebrew does not support dependencies on `--devel` installations/channels. Example: https://github.com/sass/homebrew-sass/issues/5
* Side-by-side installation of Dart 1 and 2 for developers who wanted to compare their behaviors.

The `dart@1` formula would be a long-term fix for supporting legacy applications which have not been migrated to Dart 2.