### PR TITLE
Update dart@2 recipe manually, now that it is removed from the update…

### DIFF
--- a/dart@2.rb
+++ b/dart@2.rb
@@ -1,18 +1,17 @@
 class DartAT2 < Formula
   desc "The Dart 2 SDK"
   homepage "https://www.dartlang.org/"
-  version "2.0.0-dev.69.5"
+  version "2.0.0"
 
   keg_only :versioned_formula
 
   if MacOS.prefer_64_bit?
-    url "https://storage.googleapis.com/dart-archive/channels/dev/release/2.0.0-dev.69.5/sdk/dartsdk-macos-x64-release.zip"
-    sha256 "051c145ceef9f5664fa7488b3b62742589e125e033ab474dc494b931ab8e6625"
+    url "https://storage.googleapis.com/dart-archive/channels/stable/release/2.0.0/sdk/dartsdk-macos-x64-release.zip"
+    sha256 "7cb9e65cea94ce23b05af4e5224ec416b26c3fb6bf0718778b68f6a73e617cc3"
   else
-    url "https://storage.googleapis.com/dart-archive/channels/dev/release/2.0.0-dev.69.5/sdk/dartsdk-macos-ia32-release.zip"
-    sha256 "9389cf424a9119ce23bba0f402bb82ceac497fb9545433c518c5b7516eebf293"
+    url "https://storage.googleapis.com/dart-archive/channels/stable/release/2.0.0/sdk/dartsdk-macos-ia32-release.zip"
+    sha256 "da55f8fce70ca46e97304810406c89f039464be909b9b92f13986ce918da6775"
   end
-
   def install
     libexec.install Dir["*"]
     bin.install_symlink "#{libexec}/bin/dart"
@@ -27,7 +26,8 @@ class DartAT2 < Formula
   end
 
   def caveats; <<~EOS
-    Note that this is a prerelease version of Dart.
+    The dart@2 tap is now unneeded.  Both stable and dev versions of the regular dart tap are on Dart 2 now.
+    The dart@2 tap will be removed at some point in the future.
 
     Please note the path to the Dart SDK:
       #{opt_libexec}


### PR DESCRIPTION
… scripts.

Inserted caveat that it will be removed, and is no longer necessary.