### PR TITLE
Add beta channel formula

### DIFF
--- a/dart-beta.rb
+++ b/dart-beta.rb
@@ -1,0 +1,58 @@
+class DartBeta < Formula
+  desc "The Dart Beta SDK"
+  homepage "https://dart.dev"
+
+  conflicts_with "dart", :because => "dart ships the same binaries"
+
+  version "2.8.0-dev.18.0"
+  if OS.mac?
+    url "https://storage.googleapis.com/dart-archive/channels/dev/release/2.8.0-dev.18.0/sdk/dartsdk-macos-x64-release.zip"
+    sha256 "10c63a444fe382061d9b74d9b609920a42b8c81bcd2c73917734e821faca0416"
+  elsif OS.linux? && Hardware::CPU.intel?
+    if Hardware::CPU.is_64_bit?
+      url "https://storage.googleapis.com/dart-archive/channels/dev/release/2.8.0-dev.18.0/sdk/dartsdk-linux-x64-release.zip"
+      sha256 "befe8984db19fa4ba41c1b4c4bab07c5a5103cc95836ac6df205c80def1e0964"
+    else
+      url "https://storage.googleapis.com/dart-archive/channels/dev/release/2.8.0-dev.18.0/sdk/dartsdk-linux-ia32-release.zip"
+      sha256 "aaac9e5d223deecaa7e831615fcefd61a8931c26e8abe8484c1f0e32fda261e5"
+    end
+  elsif OS.linux? && Hardware::CPU.arm?
+    if Hardware::CPU.is_64_bit?
+      url "https://storage.googleapis.com/dart-archive/channels/dev/release/2.8.0-dev.18.0/sdk/dartsdk-linux-arm64-release.zip"
+      sha256 "dffa965f230209e9ebff1d99e8aed5c8067686cd588d12037a27e9335c94788e"
+    else
+      url "https://storage.googleapis.com/dart-archive/channels/dev/release/2.8.0-dev.18.0/sdk/dartsdk-linux-arm-release.zip"
+      sha256 "630a819d162b42cbf740fd7927a42a8325fb651d2ce8c5465252a3dd99f887e2"
+    end
+  end
+
+  def install
+    libexec.install Dir["*"]
+    bin.install_symlink "#{libexec}/bin/dart"
+    bin.write_exec_script Dir["#{libexec}/bin/{pub,dart?*}"]
+  end
+
+  def shim_script(target)
+    <<~EOS
+      #!/usr/bin/env bash
+      exec "#{prefix}/#{target}" "$@"
+    EOS
+  end
+
+  def caveats
+    <<~EOS
+      Please note the path to the Dart SDK:
+        #{opt_libexec}
+    EOS
+  end
+
+  test do
+    (testpath/"sample.dart").write <<~EOS
+      void main() {
+        print(r"test message");
+      }
+    EOS
+
+    assert_equal "test message\n", shell_output("#{bin}/dart sample.dart")
+  end
+end

--- a/dart.rb
+++ b/dart.rb
@@ -2,6 +2,8 @@ class Dart < Formula
   desc "The Dart SDK"
   homepage "https://dart.dev"
 
+  conflicts_with "dart-beta", :because => "dart-beta ships the same binaries"
+
   version "2.7.2"
   if OS.mac?
     url "https://storage.googleapis.com/dart-archive/channels/stable/release/2.7.2/sdk/dartsdk-macos-x64-release.zip"


### PR DESCRIPTION
This adds dart-beta formula for the upcoming beta channel.

The dart-beta and dart formulas are mutually exclusive. The initial version in dart-beta is not actually a beta release, but simply the latest dev release. It will be updated when the first real beta release is published.

Closes https://github.com/dart-lang/sdk/issues/40990