### PR TITLE
Remove `shim_script` function

### DIFF
--- a/dart-beta.rb
+++ b/dart-beta.rb
@@ -32,13 +32,6 @@ class DartBeta < Formula
     bin.write_exec_script Dir["#{libexec}/bin/{pub,dart?*}"]
   end
 
-  def shim_script(target)
-    <<~EOS
-      #!/usr/bin/env bash
-      exec "#{prefix}/#{target}" "$@"
-    EOS
-  end
-
   def caveats
     <<~EOS
       Please note the path to the Dart SDK:

--- a/dart.rb
+++ b/dart.rb
@@ -56,13 +56,6 @@ class Dart < Formula
     bin.write_exec_script Dir["#{libexec}/bin/{pub,dart?*}"]
   end
 
-  def shim_script(target)
-    <<~EOS
-      #!/usr/bin/env bash
-      exec "#{prefix}/#{target}" "$@"
-    EOS
-  end
-
   def caveats
     <<~EOS
       Please note the path to the Dart SDK:

--- a/dart@2.rb
+++ b/dart@2.rb
@@ -18,13 +18,6 @@ class DartAT2 < Formula
     bin.write_exec_script Dir["#{libexec}/bin/{pub,dart?*}"]
   end
 
-  def shim_script(target)
-    <<~EOS
-      #!/usr/bin/env bash
-      exec "#{prefix}/#{target}" "$@"
-    EOS
-  end
-
   def caveats; <<~EOS
     The dart@2 tap is now unneeded.  Both stable and dev versions of the regular dart tap are on Dart 2 now.
     The dart@2 tap will be removed at some point in the future.


### PR DESCRIPTION
Only used to link to content-shell and dartium, which are not in v2+