### PR TITLE
Changed DEVEL to HEAD

### DIFF
--- a/dart.rb
+++ b/dart.rb
@@ -26,7 +26,7 @@ class Dart < Formula
     end
   end
 
-  devel do
+  head do
     version "2.9.0-13.0.dev"
     if OS.mac?
       url "https://storage.googleapis.com/dart-archive/channels/dev/release/2.9.0-13.0.dev/sdk/dartsdk-macos-x64-release.zip"


### PR DESCRIPTION
Fixes Homebrew warning and issue

Warning: Calling 'devel' blocks in formulae is deprecated! Use 'head' blocks or @-versioned formulae instead.
Please report this issue to the dart-lang/dart tap (not Homebrew/brew or Homebrew/core), or even better, submit a PR to fix it:
  /usr/local/Homebrew/Library/Taps/dart-lang/homebrew-dart/dart.rb:29