### PR TITLE
Use head block instead of the deprecated devel

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,11 +27,11 @@ in your IDE (like WebStorm).
 
 ## Dev Releases
 
-To install dev channel releases, instead of the stable ones, add a `--devel`
+To install dev channel releases, instead of the stable ones, add a `--head`
 flag after the brew commands:
 
 ```shell
-brew install dart --devel
+brew install dart --head
 ```
 
 ## Updating

--- a/dart.rb
+++ b/dart.rb
@@ -26,7 +26,7 @@ class Dart < Formula
     end
   end
 
-  devel do
+  head do
     version "2.9.0-13.0.dev"
     if OS.mac?
       url "https://storage.googleapis.com/dart-archive/channels/dev/release/2.9.0-13.0.dev/sdk/dartsdk-macos-x64-release.zip"


### PR DESCRIPTION
As of version 3.0.0 of Homebrew, [`devel` blocks are deprecated.](https://github.com/Homebrew/brew/commit/22857b56b9ff732c83f9bde3b58c3d579ac7f3b1) We should use `head` blocks instead.

I also created [a branch ](https://github.com/Stargator/homebrew-dart/tree/create-dart-devel)to just setup a `dart-devel` formula similar to `dart-beta`, but I **think** the `head` blocks work as the [docs describe](https://docs.brew.sh/Formula-Cookbook#unstable-versions-devel-head):
> head URLs (activated by passing --HEAD) build the development cutting edge.

Which I think covers this.