### PR TITLE
Versioned minor formulae

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,17 @@ the latest dev release, run:
 brew reinstall dart
 ```
 
+## Specific stable versions
+
+To install a specific dart version run `brew install dart@2.8`. 
+This installs the latest `2.8` release including security patches, i.e. `2.8.1`.
+
+To use the specific version in your IDE or in scripts use the SDK you find under `/usr/local/opt/dart@2.8/libexec`.
+
+It is supported to installing multiple dart versions in parallel. The `dart` executable 
+in `PATH` will continue to link to the `dart` or `dart-beta` formulae. 
+Installing `dart@2.8` alone doesn't add the `dart` executable to the user `PATH`. 
+
 ## SDK path
 
 Many tools, such as editors, ask you to specify the Dart SDK installation directory.

--- a/README.md
+++ b/README.md
@@ -58,8 +58,8 @@ This installs the latest `2.8` release including security patches, i.e. `2.8.1`.
 
 To use the specific version in your IDE or in scripts use the SDK you find under `/usr/local/opt/dart@2.8/libexec`.
 
-It is supported to installing multiple dart versions in parallel. The `dart` executable 
-in `PATH` will continue to link to the `dart` or `dart-beta` formulae. 
+It is supported to install multiple dart versions in parallel. The `dart` executable 
+in `PATH` will continue to link to the `dart` or `dart-beta` formula. 
 Installing `dart@2.8` alone doesn't add the `dart` executable to the user `PATH`. 
 
 ## SDK path

--- a/dart@2.0.rb
+++ b/dart@2.0.rb
@@ -1,0 +1,43 @@
+class DartAT20 < Formula
+  desc "The Dart SDK"
+  homepage "https://www.dartlang.org/"
+
+  version "2.0.0"
+  keg_only :versioned_formula
+  if Hardware::CPU.is_64_bit?
+    url "https://storage.googleapis.com/dart-archive/channels/stable/release/2.0.0/sdk/dartsdk-macos-x64-release.zip"
+    sha256 "7cb9e65cea94ce23b05af4e5224ec416b26c3fb6bf0718778b68f6a73e617cc3"
+  else
+    url "https://storage.googleapis.com/dart-archive/channels/stable/release/2.0.0/sdk/dartsdk-macos-ia32-release.zip"
+    sha256 "da55f8fce70ca46e97304810406c89f039464be909b9b92f13986ce918da6775"
+  end
+
+  def install
+    libexec.install Dir["*"]
+    bin.install_symlink "#{libexec}/bin/dart"
+    bin.write_exec_script Dir["#{libexec}/bin/{pub,dart?*}"]
+  end
+
+  def shim_script(target)
+    <<~EOS
+      #!/usr/bin/env bash
+      exec "#{prefix}/#{target}" "$@"
+    EOS
+  end
+
+  def caveats; <<~EOS
+    Please note the path to the Dart SDK:
+      #{opt_libexec}
+    EOS
+  end
+
+  test do
+    (testpath/"sample.dart").write <<~EOS
+      void main() {
+        print(r"test message");
+      }
+    EOS
+
+    assert_equal "test message\n", shell_output("#{bin}/dart sample.dart")
+  end
+end

--- a/dart@2.1.rb
+++ b/dart@2.1.rb
@@ -1,0 +1,43 @@
+class DartAT21 < Formula
+  desc "The Dart SDK"
+  homepage "https://www.dartlang.org/"
+
+  version "2.1.1"
+  keg_only :versioned_formula
+  if Hardware::CPU.is_64_bit?
+    url "https://storage.googleapis.com/dart-archive/channels/stable/release/2.1.1/sdk/dartsdk-macos-x64-release.zip"
+    sha256 "2f80bbbc16b4cbd872f6e31912aa87a537412f3b417af99003521c8790542887"
+  else
+    url "https://storage.googleapis.com/dart-archive/channels/stable/release/2.1.1/sdk/dartsdk-macos-ia32-release.zip"
+    sha256 "a19a73189f9dc2a3ff4557566c358b01774deab4811706e74e1bddeb43a76048"
+  end
+
+  def install
+    libexec.install Dir["*"]
+    bin.install_symlink "#{libexec}/bin/dart"
+    bin.write_exec_script Dir["#{libexec}/bin/{pub,dart?*}"]
+  end
+
+  def shim_script(target)
+    <<~EOS
+      #!/usr/bin/env bash
+      exec "#{prefix}/#{target}" "$@"
+    EOS
+  end
+
+  def caveats; <<~EOS
+    Please note the path to the Dart SDK:
+      #{opt_libexec}
+    EOS
+  end
+
+  test do
+    (testpath/"sample.dart").write <<~EOS
+      void main() {
+        print(r"test message");
+      }
+    EOS
+
+    assert_equal "test message\n", shell_output("#{bin}/dart sample.dart")
+  end
+end

--- a/dart@2.10.rb
+++ b/dart@2.10.rb
@@ -1,0 +1,56 @@
+class DartAT210 < Formula
+  desc "The Dart SDK"
+  homepage "https://www.dartlang.org/"
+
+  version "2.10.4"
+  keg_only :versioned_formula
+  if OS.mac?
+    url "https://storage.googleapis.com/dart-archive/channels/stable/release/2.10.4/sdk/dartsdk-macos-x64-release.zip"
+    sha256 "45c28ed3eb036edd1f5b0a7a073afddd1900f96abc3be085fe9335a424a228b4"
+  elsif OS.linux? && Hardware::CPU.intel?
+    if Hardware::CPU.is_64_bit?
+      url "https://storage.googleapis.com/dart-archive/channels/stable/release/2.10.4/sdk/dartsdk-linux-x64-release.zip"
+      sha256 "789f56cb6da0cfb2b97d9ea0942bc3f26fc20fd86256b1101e0147aa9790585e"
+    else
+      url "https://storage.googleapis.com/dart-archive/channels/stable/release/2.10.4/sdk/dartsdk-linux-ia32-release.zip"
+      sha256 "280701c2a225ef08bc14f5a2e7e2c75350b1ae3d78f7fd27cbb2a0b66674d83b"
+    end
+  elsif OS.linux? && Hardware::CPU.arm?
+    if Hardware::CPU.is_64_bit?
+      url "https://storage.googleapis.com/dart-archive/channels/stable/release/2.10.4/sdk/dartsdk-linux-arm64-release.zip"
+      sha256 "13f085e477f93aa3884dbbcaaacb77c08d8ab6712b332a4f399b39f4c11be410"
+    else
+      url "https://storage.googleapis.com/dart-archive/channels/stable/release/2.10.4/sdk/dartsdk-linux-arm-release.zip"
+      sha256 "9f41091c8542fd50f0bd60fa9e5d4ceefe9c754a21684f802f89b54d2abeec83"
+    end
+  end
+
+  def install
+    libexec.install Dir["*"]
+    bin.install_symlink "#{libexec}/bin/dart"
+    bin.write_exec_script Dir["#{libexec}/bin/{pub,dart?*}"]
+  end
+
+  def shim_script(target)
+    <<~EOS
+      #!/usr/bin/env bash
+      exec "#{prefix}/#{target}" "$@"
+    EOS
+  end
+
+  def caveats; <<~EOS
+    Please note the path to the Dart SDK:
+      #{opt_libexec}
+    EOS
+  end
+
+  test do
+    (testpath/"sample.dart").write <<~EOS
+      void main() {
+        print(r"test message");
+      }
+    EOS
+
+    assert_equal "test message\n", shell_output("#{bin}/dart sample.dart")
+  end
+end

--- a/dart@2.2.rb
+++ b/dart@2.2.rb
@@ -1,0 +1,43 @@
+class DartAT22 < Formula
+  desc "The Dart SDK"
+  homepage "https://www.dartlang.org/"
+
+  version "2.2.0"
+  keg_only :versioned_formula
+  if Hardware::CPU.is_64_bit?
+    url "https://storage.googleapis.com/dart-archive/channels/stable/release/2.2.0/sdk/dartsdk-macos-x64-release.zip"
+    sha256 "9438afb49b69ac655882036c214e343232fdcd5af24607e6058e2def33261197"
+  else
+    url "https://storage.googleapis.com/dart-archive/channels/stable/release/2.2.0/sdk/dartsdk-macos-ia32-release.zip"
+    sha256 "78a2da74ea83ee092463a9901467492ef885f6e378353b0a44481fdf40ea81c7"
+  end
+
+  def install
+    libexec.install Dir["*"]
+    bin.install_symlink "#{libexec}/bin/dart"
+    bin.write_exec_script Dir["#{libexec}/bin/{pub,dart?*}"]
+  end
+
+  def shim_script(target)
+    <<~EOS
+      #!/usr/bin/env bash
+      exec "#{prefix}/#{target}" "$@"
+    EOS
+  end
+
+  def caveats; <<~EOS
+    Please note the path to the Dart SDK:
+      #{opt_libexec}
+    EOS
+  end
+
+  test do
+    (testpath/"sample.dart").write <<~EOS
+      void main() {
+        print(r"test message");
+      }
+    EOS
+
+    assert_equal "test message\n", shell_output("#{bin}/dart sample.dart")
+  end
+end

--- a/dart@2.3.rb
+++ b/dart@2.3.rb
@@ -1,0 +1,43 @@
+class DartAT23 < Formula
+  desc "The Dart SDK"
+  homepage "https://www.dartlang.org/"
+
+  version "2.3.2"
+  keg_only :versioned_formula
+  if Hardware::CPU.is_64_bit?
+    url "https://storage.googleapis.com/dart-archive/channels/stable/release/2.3.2/sdk/dartsdk-macos-x64-release.zip"
+    sha256 "2643c435c4c8fe1b39c9d73cb63ba8a170ac42609b6e91e08416911bc0418031"
+  else
+    url "https://storage.googleapis.com/dart-archive/channels/stable/release/2.3.2/sdk/dartsdk-macos-ia32-release.zip"
+    sha256 "d92aa28a3c1742130f92e70c0bf767f7c3f6456392d7bc93fdefbfcfbb5a0e99"
+  end
+
+  def install
+    libexec.install Dir["*"]
+    bin.install_symlink "#{libexec}/bin/dart"
+    bin.write_exec_script Dir["#{libexec}/bin/{pub,dart?*}"]
+  end
+
+  def shim_script(target)
+    <<~EOS
+      #!/usr/bin/env bash
+      exec "#{prefix}/#{target}" "$@"
+    EOS
+  end
+
+  def caveats; <<~EOS
+    Please note the path to the Dart SDK:
+      #{opt_libexec}
+    EOS
+  end
+
+  test do
+    (testpath/"sample.dart").write <<~EOS
+      void main() {
+        print(r"test message");
+      }
+    EOS
+
+    assert_equal "test message\n", shell_output("#{bin}/dart sample.dart")
+  end
+end

--- a/dart@2.4.rb
+++ b/dart@2.4.rb
@@ -1,0 +1,43 @@
+class DartAT24 < Formula
+  desc "The Dart SDK"
+  homepage "https://www.dartlang.org/"
+
+  version "2.4.1"
+  keg_only :versioned_formula
+  if Hardware::CPU.is_64_bit?
+    url "https://storage.googleapis.com/dart-archive/channels/stable/release/2.4.1/sdk/dartsdk-macos-x64-release.zip"
+    sha256 "62006127bd3acd1b7eb2e4fc7baed061eb19b80c4ba4af481db5244a081fff3e"
+  else
+    url "https://storage.googleapis.com/dart-archive/channels/stable/release/2.4.1/sdk/dartsdk-macos-ia32-release.zip"
+    sha256 "3591578902f3b3ee155aa90bf893f3d0b50fd12567454a8f980440fa8dd1ff23"
+  end
+
+  def install
+    libexec.install Dir["*"]
+    bin.install_symlink "#{libexec}/bin/dart"
+    bin.write_exec_script Dir["#{libexec}/bin/{pub,dart?*}"]
+  end
+
+  def shim_script(target)
+    <<~EOS
+      #!/usr/bin/env bash
+      exec "#{prefix}/#{target}" "$@"
+    EOS
+  end
+
+  def caveats; <<~EOS
+    Please note the path to the Dart SDK:
+      #{opt_libexec}
+    EOS
+  end
+
+  test do
+    (testpath/"sample.dart").write <<~EOS
+      void main() {
+        print(r"test message");
+      }
+    EOS
+
+    assert_equal "test message\n", shell_output("#{bin}/dart sample.dart")
+  end
+end

--- a/dart@2.5.rb
+++ b/dart@2.5.rb
@@ -1,0 +1,43 @@
+class DartAT25 < Formula
+  desc "The Dart SDK"
+  homepage "https://www.dartlang.org/"
+
+  version "2.5.2"
+  keg_only :versioned_formula
+  if Hardware::CPU.is_64_bit?
+    url "https://storage.googleapis.com/dart-archive/channels/stable/release/2.5.2/sdk/dartsdk-macos-x64-release.zip"
+    sha256 "b433b05ce353d3683c53632fdafd053aaab6c49014c8702fa63936cdc43ea8d6"
+  else
+    url "https://storage.googleapis.com/dart-archive/channels/stable/release/2.5.2/sdk/dartsdk-macos-ia32-release.zip"
+    sha256 "f5c3f7b001a734726140e8941f0768f3365193d27024a762b769d7c03304064f"
+  end
+
+  def install
+    libexec.install Dir["*"]
+    bin.install_symlink "#{libexec}/bin/dart"
+    bin.write_exec_script Dir["#{libexec}/bin/{pub,dart?*}"]
+  end
+
+  def shim_script(target)
+    <<~EOS
+      #!/usr/bin/env bash
+      exec "#{prefix}/#{target}" "$@"
+    EOS
+  end
+
+  def caveats; <<~EOS
+    Please note the path to the Dart SDK:
+      #{opt_libexec}
+    EOS
+  end
+
+  test do
+    (testpath/"sample.dart").write <<~EOS
+      void main() {
+        print(r"test message");
+      }
+    EOS
+
+    assert_equal "test message\n", shell_output("#{bin}/dart sample.dart")
+  end
+end

--- a/dart@2.6.rb
+++ b/dart@2.6.rb
@@ -1,0 +1,61 @@
+class DartAT26 < Formula
+  desc "The Dart SDK"
+  homepage "https://www.dartlang.org/"
+  
+  version "2.6.1"
+  keg_only :versioned_formula
+  if OS.mac?
+    if Hardware::CPU.is_64_bit?
+      url "https://storage.googleapis.com/dart-archive/channels/stable/release/2.6.1/sdk/dartsdk-macos-x64-release.zip"
+      sha256 "3063a3151e91367fff95f63c781519a54674cc5e8b9bc847e2c6de96ed611a14"
+    else
+      url "https://storage.googleapis.com/dart-archive/channels/stable/release/2.6.1/sdk/dartsdk-macos-ia32-release.zip"
+      sha256 "161122c60c89db5049a7617630d7a492cdb6bb2e73b23daf49a16bd9e2c0c52d"
+    end
+  elsif OS.linux? && Hardware::CPU.intel?
+    if Hardware::CPU.is_64_bit?
+      url "https://storage.googleapis.com/dart-archive/channels/stable/release/2.6.1/sdk/dartsdk-linux-x64-release.zip"
+      sha256 "8cff83660635b982e1bcca700a30029dcab71bd8ce1c5eb0c8102ee6c51a587c"
+    else
+      url "https://storage.googleapis.com/dart-archive/channels/stable/release/2.6.1/sdk/dartsdk-linux-ia32-release.zip"
+      sha256 "3e6563cd028f83bdf8ec167cb499dee278abd81e16f1524b3c1b377c26d09283"
+    end
+  elsif OS.linux? && Hardware::CPU.arm?
+    if Hardware::CPU.is_64_bit?
+      url "https://storage.googleapis.com/dart-archive/channels/stable/release/2.6.1/sdk/dartsdk-linux-arm64-release.zip"
+      sha256 "4570933406a042fadfad1dc4b664cfcf5ab7c10ca83a0d0e9e7d5a7f362ac0b2"
+    else
+      url "https://storage.googleapis.com/dart-archive/channels/stable/release/2.6.1/sdk/dartsdk-linux-arm-release.zip"
+      sha256 "cf080fa8bdeae9b1f765ba3efab0940522506ec3077eb2751b4afd0a6448e407"
+    end
+  end
+
+  def install
+    libexec.install Dir["*"]
+    bin.install_symlink "#{libexec}/bin/dart"
+    bin.write_exec_script Dir["#{libexec}/bin/{pub,dart?*}"]
+  end
+
+  def shim_script(target)
+    <<~EOS
+      #!/usr/bin/env bash
+      exec "#{prefix}/#{target}" "$@"
+    EOS
+  end
+
+  def caveats; <<~EOS
+    Please note the path to the Dart SDK:
+      #{opt_libexec}
+    EOS
+  end
+
+  test do
+    (testpath/"sample.dart").write <<~EOS
+      void main() {
+        print(r"test message");
+      }
+    EOS
+
+    assert_equal "test message\n", shell_output("#{bin}/dart sample.dart")
+  end
+end

--- a/dart@2.7.rb
+++ b/dart@2.7.rb
@@ -1,0 +1,61 @@
+class DartAT27 < Formula
+  desc "The Dart SDK"
+  homepage "https://www.dartlang.org/"
+
+  version "2.7.0"
+  keg_only :versioned_formula
+  if OS.mac?
+    if Hardware::CPU.is_64_bit?
+      url "https://storage.googleapis.com/dart-archive/channels/stable/release/2.7.0/sdk/dartsdk-macos-x64-release.zip"
+      sha256 "f9d2f5b579fe2a1cfd14fe558d20adfa7c7a326a980768335f85ec1ed3611ad2"
+    else
+      url "https://storage.googleapis.com/dart-archive/channels/stable/release/2.7.0/sdk/dartsdk-macos-ia32-release.zip"
+      sha256 "4e0c2a09d85ebbbed55882a105a86a482a151f71a27aec21c2c2125de7b501cf"
+    end
+  elsif OS.linux? && Hardware::CPU.intel?
+    if Hardware::CPU.is_64_bit?
+      url "https://storage.googleapis.com/dart-archive/channels/stable/release/2.7.0/sdk/dartsdk-linux-x64-release.zip"
+      sha256 "65844622eb095be903d057d78af4826bfc204d8ea156f77a14b954520f019827"
+    else
+      url "https://storage.googleapis.com/dart-archive/channels/stable/release/2.7.0/sdk/dartsdk-linux-ia32-release.zip"
+      sha256 "a503731077c332fbde70c06b602efc5024d59e7331f08dba087d2d8bbf4e6c23"
+    end
+  elsif OS.linux? && Hardware::CPU.arm?
+    if Hardware::CPU.is_64_bit?
+      url "https://storage.googleapis.com/dart-archive/channels/stable/release/2.7.0/sdk/dartsdk-linux-arm64-release.zip"
+      sha256 "0328af535743622130fa7b89969bac34b11c116cb99d185ad1161ddfac457dec"
+    else
+      url "https://storage.googleapis.com/dart-archive/channels/stable/release/2.7.0/sdk/dartsdk-linux-arm-release.zip"
+      sha256 "2270ae2d3e467c539dcc6358312bba949f2614f7da78225e7a1ba5b57981ca0c"
+    end
+  end
+
+  def install
+    libexec.install Dir["*"]
+    bin.install_symlink "#{libexec}/bin/dart"
+    bin.write_exec_script Dir["#{libexec}/bin/{pub,dart?*}"]
+  end
+
+  def shim_script(target)
+    <<~EOS
+      #!/usr/bin/env bash
+      exec "#{prefix}/#{target}" "$@"
+    EOS
+  end
+
+  def caveats; <<~EOS
+    Please note the path to the Dart SDK:
+      #{opt_libexec}
+    EOS
+  end
+
+  test do
+    (testpath/"sample.dart").write <<~EOS
+      void main() {
+        print(r"test message");
+      }
+    EOS
+
+    assert_equal "test message\n", shell_output("#{bin}/dart sample.dart")
+  end
+end

--- a/dart@2.8.rb
+++ b/dart@2.8.rb
@@ -1,0 +1,56 @@
+class DartAT28 < Formula
+  desc "The Dart SDK"
+  homepage "https://www.dartlang.org/"
+
+  version "2.8.1"
+  keg_only :versioned_formula
+  if OS.mac?
+    url "https://storage.googleapis.com/dart-archive/channels/stable/release/2.8.1/sdk/dartsdk-macos-x64-release.zip"
+    sha256 "c94e03f9f0d4fa90e88ec70861b2b0661a5bda1aa4da4329c3751aaf0b4ef61a"
+  elsif OS.linux? && Hardware::CPU.intel?
+    if Hardware::CPU.is_64_bit?
+      url "https://storage.googleapis.com/dart-archive/channels/stable/release/2.8.1/sdk/dartsdk-linux-x64-release.zip"
+      sha256 "7ec2c65ab140066aba9cb85254322817e698df3d3f49d5835cd0b3d1139fdf93"
+    else
+      url "https://storage.googleapis.com/dart-archive/channels/stable/release/2.8.1/sdk/dartsdk-linux-ia32-release.zip"
+      sha256 "f0cf290579526237bb8e8e2d205d1de61c8629762a7e763fcc04d7552b5fa370"
+    end
+  elsif OS.linux? && Hardware::CPU.arm?
+    if Hardware::CPU.is_64_bit?
+      url "https://storage.googleapis.com/dart-archive/channels/stable/release/2.8.1/sdk/dartsdk-linux-arm64-release.zip"
+      sha256 "b01dc83b77b8eddce33e18ae35bed98e18faae77eccff08178a21c9ea913ebb9"
+    else
+      url "https://storage.googleapis.com/dart-archive/channels/stable/release/2.8.1/sdk/dartsdk-linux-arm-release.zip"
+      sha256 "68ee57689bcff7cd7341db05926b291fbcf5bc2a7fea9d8dd8105b8ec1a73abd"
+    end
+  end
+
+  def install
+    libexec.install Dir["*"]
+    bin.install_symlink "#{libexec}/bin/dart"
+    bin.write_exec_script Dir["#{libexec}/bin/{pub,dart?*}"]
+  end
+
+  def shim_script(target)
+    <<~EOS
+      #!/usr/bin/env bash
+      exec "#{prefix}/#{target}" "$@"
+    EOS
+  end
+
+  def caveats; <<~EOS
+    Please note the path to the Dart SDK:
+      #{opt_libexec}
+    EOS
+  end
+
+  test do
+    (testpath/"sample.dart").write <<~EOS
+      void main() {
+        print(r"test message");
+      }
+    EOS
+
+    assert_equal "test message\n", shell_output("#{bin}/dart sample.dart")
+  end
+end

--- a/dart@2.9.rb
+++ b/dart@2.9.rb
@@ -1,0 +1,56 @@
+class DartAT29 < Formula
+  desc "The Dart SDK"
+  homepage "https://www.dartlang.org/"
+
+  version "2.9.1"
+  keg_only :versioned_formula
+  if OS.mac?
+    url "https://storage.googleapis.com/dart-archive/channels/stable/release/2.9.1/sdk/dartsdk-macos-x64-release.zip"
+    sha256 "f7e41307222fd9b856acefebb6bc9137c5af4ecbca062736367b83f4b3978eb0"
+  elsif OS.linux? && Hardware::CPU.intel?
+    if Hardware::CPU.is_64_bit?
+      url "https://storage.googleapis.com/dart-archive/channels/stable/release/2.9.1/sdk/dartsdk-linux-x64-release.zip"
+      sha256 "8e092105482e3e1be90af44962e3b7973a20cd8f71aa9f6e07199174a58e0eed"
+    else
+      url "https://storage.googleapis.com/dart-archive/channels/stable/release/2.9.1/sdk/dartsdk-linux-ia32-release.zip"
+      sha256 "8492ec94a07c6100f1a097864668e4b9063f3b1ed9f05c01dee2d59158ae6a04"
+    end
+  elsif OS.linux? && Hardware::CPU.arm?
+    if Hardware::CPU.is_64_bit?
+      url "https://storage.googleapis.com/dart-archive/channels/stable/release/2.9.1/sdk/dartsdk-linux-arm64-release.zip"
+      sha256 "bf92f51f688ef0bbd4d7c62c7ab391da3f632cf12280bc67a100a09a5b89cf02"
+    else
+      url "https://storage.googleapis.com/dart-archive/channels/stable/release/2.9.1/sdk/dartsdk-linux-arm-release.zip"
+      sha256 "e393c05136571bf7c4879a2bfe207a768be449a3d0bcc8a7ff700b01c4330109"
+    end
+  end
+
+  def install
+    libexec.install Dir["*"]
+    bin.install_symlink "#{libexec}/bin/dart"
+    bin.write_exec_script Dir["#{libexec}/bin/{pub,dart?*}"]
+  end
+
+  def shim_script(target)
+    <<~EOS
+      #!/usr/bin/env bash
+      exec "#{prefix}/#{target}" "$@"
+    EOS
+  end
+
+  def caveats; <<~EOS
+    Please note the path to the Dart SDK:
+      #{opt_libexec}
+    EOS
+  end
+
+  test do
+    (testpath/"sample.dart").write <<~EOS
+      void main() {
+        print(r"test message");
+      }
+    EOS
+
+    assert_equal "test message\n", shell_output("#{bin}/dart sample.dart")
+  end
+end

--- a/dart@2.9.rb
+++ b/dart@2.9.rb
@@ -2,26 +2,26 @@ class DartAT29 < Formula
   desc "The Dart SDK"
   homepage "https://www.dartlang.org/"
 
-  version "2.9.1"
+  version "2.9.3"
   keg_only :versioned_formula
   if OS.mac?
-    url "https://storage.googleapis.com/dart-archive/channels/stable/release/2.9.1/sdk/dartsdk-macos-x64-release.zip"
-    sha256 "f7e41307222fd9b856acefebb6bc9137c5af4ecbca062736367b83f4b3978eb0"
+    url "https://storage.googleapis.com/dart-archive/channels/stable/release/2.9.3/sdk/dartsdk-macos-x64-release.zip"
+    sha256 "f29ff9955b024bcf2aa6ffed6f8f66dc37a95be594496c9a2d695e67ac34b7ac"
   elsif OS.linux? && Hardware::CPU.intel?
     if Hardware::CPU.is_64_bit?
-      url "https://storage.googleapis.com/dart-archive/channels/stable/release/2.9.1/sdk/dartsdk-linux-x64-release.zip"
-      sha256 "8e092105482e3e1be90af44962e3b7973a20cd8f71aa9f6e07199174a58e0eed"
+      url "https://storage.googleapis.com/dart-archive/channels/stable/release/2.9.3/sdk/dartsdk-linux-x64-release.zip"
+      sha256 "6719026f526f3171274dc9d8322c33fd9ec22e659e8dd833c587038211b83b04"
     else
-      url "https://storage.googleapis.com/dart-archive/channels/stable/release/2.9.1/sdk/dartsdk-linux-ia32-release.zip"
-      sha256 "8492ec94a07c6100f1a097864668e4b9063f3b1ed9f05c01dee2d59158ae6a04"
+      url "https://storage.googleapis.com/dart-archive/channels/stable/release/2.9.3/sdk/dartsdk-linux-ia32-release.zip"
+      sha256 "82116dbc7e16ca4bd04c090be2bb6014bce8d0a71823a1ffdc5842b658b6132c"
     end
   elsif OS.linux? && Hardware::CPU.arm?
     if Hardware::CPU.is_64_bit?
-      url "https://storage.googleapis.com/dart-archive/channels/stable/release/2.9.1/sdk/dartsdk-linux-arm64-release.zip"
-      sha256 "bf92f51f688ef0bbd4d7c62c7ab391da3f632cf12280bc67a100a09a5b89cf02"
+      url "https://storage.googleapis.com/dart-archive/channels/stable/release/2.9.3/sdk/dartsdk-linux-arm64-release.zip"
+      sha256 "2be9ba987e0d0cfd89f8eb803176a7342679d892f4ea2508de7fed03e25cd93a"
     else
-      url "https://storage.googleapis.com/dart-archive/channels/stable/release/2.9.1/sdk/dartsdk-linux-arm-release.zip"
-      sha256 "e393c05136571bf7c4879a2bfe207a768be449a3d0bcc8a7ff700b01c4330109"
+      url "https://storage.googleapis.com/dart-archive/channels/stable/release/2.9.3/sdk/dartsdk-linux-arm-release.zip"
+      sha256 "fe5e180c901b4a6bf802211bf7b4918d321c3924f55088339f7fe3a01a8cc735"
     end
   end
 


### PR DESCRIPTION
Fixes #46 

### Description

Allows the installation of multiple Dart versions in parallel. That's especially helpful as a package author when testing libraries against specific dart version.

### Justification

Before I had to manually download old Dart SDKs from the website or install old formulae from source  `brew install --build-from-source https://github.com/dart-lang/homebrew-dart/blob/e022ef73a2b68516925ffa8076968ddcaef92c11/dart.rb`. The latter was especially flawed because old formula became incompatible with the latest homebrew version. I ended up maintaining this collection of formulae for each version on my own and would like to see them integrated into the main project now.

### Usage
```
$ brew install dart@2.7
==> Caveats
Please note the path to the Dart SDK:
  /usr/local/opt/dart@2.7/libexec

dart@2.7 is keg-only, which means it was not symlinked into /usr/local,
because this is an alternate version of another formula.

==> Summary
🍺  /usr/local/Cellar/dart@2.7/2.7.0: 474 files, 463.4MB, built in 7 seconds
```

```
$ brew install dart@2.8
==> Caveats
Please note the path to the Dart SDK:
  /usr/local/opt/dart@2.8/libexec

dart@2.8 is keg-only, which means it was not symlinked into /usr/local,
because this is an alternate version of another formula.

If you need to have dart@2.8 first in your PATH run:
  echo 'export PATH="/usr/local/opt/dart@2.8/bin:$PATH"' >> ~/.zshrc

==> Summary
🍺  /usr/local/Cellar/dart@2.8/2.8.1: 502 files, 486MB, built in 7 seconds
```

Installs versions in parallel but doesn't link them because I've set `keg_only :versioned_formula`.

`/usr/local/Cellar`
<img width="246" alt="Screen-Shot-2020-08-19-14-48-05 25" src="https://user-images.githubusercontent.com/1096485/90643536-ff244d00-e233-11ea-892f-03f28fc68b06.png">

### Maintainance consequences
- Every new minor and major Dart release requires a new formula to be created.
- Every patch release requires updates in the `dart@<version>` formula and the `dart` formula
- No changes for dev releases
- Homebrew updates can cause changes in all formulae. There was only [one](https://github.com/dart-lang/homebrew-dart/issues/58) issues I remember.  

### How to test

Install from my fork

```
brew install passsy/homebrew-dart/dart@2.8
```