### PR TITLE
Add a dart pub upgrade command to CI testing

### DIFF
--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -26,7 +26,7 @@ jobs:
           sdk: ${{ matrix.sdk }}
       - id: install
         name: Install dependencies
-        run: dart pub get
+        run: dart pub upgrade
       - name: Check formatting
         run: dart format --output=none --set-exit-if-changed .
         if: always() && steps.install.outcome == 'success'


### PR DESCRIPTION
A breaking change in dart:io File means that a different set of package dependencies is needed for the stable and dev branches of the Dart SDK.

Use 'dart pub upgrade' to download a compatible set of packages for dart-homebrew test dependencies when running the CI tests.