### PR TITLE
Update package dependencies for SDK 3.0.0 compatibility

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,10 +5,10 @@ packages:
     dependency: "direct main"
     description:
       name: _discoveryapis_commons
-      sha256: f3f9fd66bf38748f4afa4621ce94b7da5413726bdfdcc84bdc3ae6cf157a0101
+      sha256: efd530ec09e3fea98529b0d2b192495e252e336c6e93ea8df1875e6e823ebc62
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.4"
+    version: "1.0.5"
   _fe_analyzer_shared:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ environment:
   sdk: '>=2.17.0 <3.0.0'
 
 dependencies:
-  _discoveryapis_commons: ^1.0.2
+  _discoveryapis_commons: ^1.0.5
   args: ^2.3.0
   googleapis: ^9.1.0
   http: ^0.13.4


### PR DESCRIPTION
A full dart pub upgrade at this time raises the minimum SDK requirement to 2.19.345, which is higher than the current stable release.

Updating only the dependency that is incompatible with Dart 3.0.0 gives a pubspec.lock with an unchanged minimum SDK requirement 2.17.0.