### PR TITLE
Remove pushing from update homebrew script.

### DIFF
--- a/bin/update_homebrew.dart
+++ b/bin/update_homebrew.dart
@@ -22,34 +22,25 @@ Future<void> updateHomeBrew(List<String> args) async {
   final parser = ArgParser()
     ..addFlag('dry-run', abbr: 'n')
     ..addOption('revision', abbr: 'r')
-    ..addOption('channel', abbr: 'c', allowed: supportedChannels)
-    ..addOption('key', abbr: 'k');
+    ..addOption('channel', abbr: 'c', allowed: supportedChannels);
   final options = parser.parse(args);
   final dryRun = options['dry-run'] as bool;
-  final revision = options['revision'] as String;
-  final channel = options['channel'] as String;
-  if ([revision, channel].contains(null)) {
-    print(
-        "Usage: update_homebrew.dart -r version -c channel [-k ssh_key] [-n]\n"
-        "  ssh_key should allow pushes to $githubRepo on github");
+  final revision = options['revision'] as String?;
+  final channel = options['channel'] as String?;
+  if (revision == null || channel == null) {
+    print("Usage: update_homebrew.dart -r version -c channel [-n]");
     exitCode = 64;
     return;
   }
 
   final repository = Directory.current.path;
-  final key = options['key'] as String?;
-  final gitEnvironment = <String, String>{};
-  if (key != null) {
-    final sshWrapper =
-        Directory.current.uri.resolve('ssh_with_key').toFilePath();
-    gitEnvironment['GIT_SSH'] = sshWrapper;
-    gitEnvironment['SSH_KEY_PATH'] = key;
+  if (await writeHomebrewInfo(channel, revision, repository, dryRun)) {
+    await runGit(
+        ['commit', '-a', '-m', 'Updated $channel channel to version $revision'],
+        repository,
+        null,
+        dryRun);
+  } else {
+    print("Channel $channel is up to date at version $revision");
   }
-  await writeHomebrewInfo(channel, revision, repository, dryRun);
-  await runGit(
-      ['commit', '-a', '-m', 'Updated $channel branch to revision $revision'],
-      repository,
-      gitEnvironment,
-      dryRun);
-  await runGit(['push'], repository, gitEnvironment, dryRun);
 }

--- a/lib/src/formula.dart
+++ b/lib/src/formula.dart
@@ -17,16 +17,11 @@ String updateFormula(String channel, String contents, String version,
   //  sha256 "<hash>"
   var filesAndHashes = RegExp(
       'channels/$channel/release'
-      r'/(\d[\w\d\-\.]*)/sdk/([\w\d\-\.]+)\"\n(\s+)sha256 \"[\da-f]+\"',
+      r'/\d[\w\d\-\.]*/sdk/([\w\d\-\.]+)\"\n(\s+)sha256 \"[\da-f]+\"',
       multiLine: true);
   return contents.replaceAllMapped(filesAndHashes, (m) {
-    var currentVersion = m.group(1);
-    if (currentVersion == version) {
-      throw ArgumentError(
-          'Channel $channel is already at version $version in homebrew.');
-    }
-    var artifact = m.group(2);
-    var indent = m.group(3);
+    var artifact = m.group(1);
+    var indent = m.group(2);
     return 'channels/$channel/release/$version/sdk/$artifact"\n'
         '${indent}sha256 "${hashes[artifact]}"';
   });


### PR DESCRIPTION
The script will soon be automatically invoked from a builder that doesn't have ssh credentials for github but instead relies on gitcookies to authenticate with git-on-borg. The push stepp will not work as it currently is and is instead removed.

The script is now idempotent so the upcoming homebrew builder can be rerun if a failed release is retried. It will instead simply not commit any updates.

The Dart release script will be changed simultaneously when this change lands to make sure the release procedure is uninterrupted.

Fix null safety issues in the parameter parsing and fix the runGit function not handling failed invocations properly.

Bug: b/227748011