### PR TITLE
add a do-not-submit workflow

### DIFF
--- a/.github/workflows/gerrit-reviewed.yml
+++ b/.github/workflows/gerrit-reviewed.yml
@@ -1,0 +1,16 @@
+# A workflow to prevent PRs from being submitted through the GitHub UI.
+
+name: Do Not Submit
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  do-not-submit:
+    name: Prevent submission (Gerrit reviewed)
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          echo "Do not submit this PR through github - this repo uses Gerrit for reviews."
+          exit 1


### PR DESCRIPTION
- add a do-not-submit workflow

This workflow will hopefully eliminate accidental merges from the github UI.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

#### Contribution guidelines:

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Many Dart repos have a weekly cadence for reviewing PRs - please allow for a week or two of latency for initial review feedback.

---
