### PR TITLE
Remove exec script for non-executable files

### DIFF
--- a/Formula/dart-beta.rb
+++ b/Formula/dart-beta.rb
@@ -29,7 +29,7 @@ class DartBeta < Formula
   def install
     libexec.install Dir["*"]
     bin.install_symlink "#{libexec}/bin/dart"
-    bin.write_exec_script Dir["#{libexec}/bin/{pub,dart?*}"]
+    bin.write_exec_script Dir["#{libexec}/bin/{pub,dart?*}"].select { |f| File.executable?(f) }
   end
 
   def caveats

--- a/Formula/dart.rb
+++ b/Formula/dart.rb
@@ -50,7 +50,7 @@ class Dart < Formula
   def install
     libexec.install Dir["*"]
     bin.install_symlink "#{libexec}/bin/dart"
-    bin.write_exec_script Dir["#{libexec}/bin/{pub,dart?*}"]
+    bin.write_exec_script Dir["#{libexec}/bin/{pub,dart?*}"].select { |f| File.executable?(f) }
   end
 
   def caveats

--- a/Formula/dart@2.0.rb
+++ b/Formula/dart@2.0.rb
@@ -35,7 +35,7 @@ class DartAT20 < Formula
   def install
     libexec.install Dir["*"]
     bin.install_symlink "#{libexec}/bin/dart"
-    bin.write_exec_script Dir["#{libexec}/bin/{pub,dart?*}"]
+    bin.write_exec_script Dir["#{libexec}/bin/{pub,dart?*}"].select { |f| File.executable?(f) }
   end
 
   def shim_script(target)

--- a/Formula/dart@2.1.rb
+++ b/Formula/dart@2.1.rb
@@ -35,7 +35,7 @@ class DartAT21 < Formula
   def install
     libexec.install Dir["*"]
     bin.install_symlink "#{libexec}/bin/dart"
-    bin.write_exec_script Dir["#{libexec}/bin/{pub,dart?*}"]
+    bin.write_exec_script Dir["#{libexec}/bin/{pub,dart?*}"].select { |f| File.executable?(f) }
   end
 
   def shim_script(target)

--- a/Formula/dart@2.10.rb
+++ b/Formula/dart@2.10.rb
@@ -30,7 +30,7 @@ class DartAT210 < Formula
   def install
     libexec.install Dir["*"]
     bin.install_symlink "#{libexec}/bin/dart"
-    bin.write_exec_script Dir["#{libexec}/bin/{pub,dart?*}"]
+    bin.write_exec_script Dir["#{libexec}/bin/{pub,dart?*}"].select { |f| File.executable?(f) }
   end
 
   def shim_script(target)

--- a/Formula/dart@2.12.rb
+++ b/Formula/dart@2.12.rb
@@ -30,7 +30,7 @@ class DartAT212 < Formula
   def install
     libexec.install Dir["*"]
     bin.install_symlink "#{libexec}/bin/dart"
-    bin.write_exec_script Dir["#{libexec}/bin/{pub,dart?*}"]
+    bin.write_exec_script Dir["#{libexec}/bin/{pub,dart?*}"].select { |f| File.executable?(f) }
   end
 
   def caveats

--- a/Formula/dart@2.13.rb
+++ b/Formula/dart@2.13.rb
@@ -30,7 +30,7 @@ class DartAT213 < Formula
   def install
     libexec.install Dir["*"]
     bin.install_symlink "#{libexec}/bin/dart"
-    bin.write_exec_script Dir["#{libexec}/bin/{pub,dart?*}"]
+    bin.write_exec_script Dir["#{libexec}/bin/{pub,dart?*}"].select { |f| File.executable?(f) }
   end
 
   def caveats

--- a/Formula/dart@2.14.rb
+++ b/Formula/dart@2.14.rb
@@ -30,7 +30,7 @@ class DartAT214 < Formula
   def install
     libexec.install Dir["*"]
     bin.install_symlink "#{libexec}/bin/dart"
-    bin.write_exec_script Dir["#{libexec}/bin/{pub,dart?*}"]
+    bin.write_exec_script Dir["#{libexec}/bin/{pub,dart?*}"].select { |f| File.executable?(f) }
   end
 
   def caveats

--- a/Formula/dart@2.15.rb
+++ b/Formula/dart@2.15.rb
@@ -30,7 +30,7 @@ class DartAT215 < Formula
   def install
     libexec.install Dir["*"]
     bin.install_symlink "#{libexec}/bin/dart"
-    bin.write_exec_script Dir["#{libexec}/bin/{pub,dart?*}"]
+    bin.write_exec_script Dir["#{libexec}/bin/{pub,dart?*}"].select { |f| File.executable?(f) }
   end
 
   def caveats

--- a/Formula/dart@2.16.rb
+++ b/Formula/dart@2.16.rb
@@ -33,7 +33,7 @@ class DartAT216 < Formula
   def install
     libexec.install Dir["*"]
     bin.install_symlink "#{libexec}/bin/dart"
-    bin.write_exec_script Dir["#{libexec}/bin/{pub,dart?*}"]
+    bin.write_exec_script Dir["#{libexec}/bin/{pub,dart?*}"].select { |f| File.executable?(f) }
   end
 
   def caveats

--- a/Formula/dart@2.17.rb
+++ b/Formula/dart@2.17.rb
@@ -33,7 +33,7 @@ class DartAT217 < Formula
   def install
     libexec.install Dir["*"]
     bin.install_symlink "#{libexec}/bin/dart"
-    bin.write_exec_script Dir["#{libexec}/bin/{pub,dart?*}"]
+    bin.write_exec_script Dir["#{libexec}/bin/{pub,dart?*}"].select { |f| File.executable?(f) }
   end
 
   def caveats

--- a/Formula/dart@2.2.rb
+++ b/Formula/dart@2.2.rb
@@ -35,7 +35,7 @@ class DartAT22 < Formula
   def install
     libexec.install Dir["*"]
     bin.install_symlink "#{libexec}/bin/dart"
-    bin.write_exec_script Dir["#{libexec}/bin/{pub,dart?*}"]
+    bin.write_exec_script Dir["#{libexec}/bin/{pub,dart?*}"].select { |f| File.executable?(f) }
   end
 
   def shim_script(target)

--- a/Formula/dart@2.3.rb
+++ b/Formula/dart@2.3.rb
@@ -35,7 +35,7 @@ class DartAT23 < Formula
   def install
     libexec.install Dir["*"]
     bin.install_symlink "#{libexec}/bin/dart"
-    bin.write_exec_script Dir["#{libexec}/bin/{pub,dart?*}"]
+    bin.write_exec_script Dir["#{libexec}/bin/{pub,dart?*}"].select { |f| File.executable?(f) }
   end
 
   def shim_script(target)

--- a/Formula/dart@2.4.rb
+++ b/Formula/dart@2.4.rb
@@ -35,7 +35,7 @@ class DartAT24 < Formula
   def install
     libexec.install Dir["*"]
     bin.install_symlink "#{libexec}/bin/dart"
-    bin.write_exec_script Dir["#{libexec}/bin/{pub,dart?*}"]
+    bin.write_exec_script Dir["#{libexec}/bin/{pub,dart?*}"].select { |f| File.executable?(f) }
   end
 
   def shim_script(target)

--- a/Formula/dart@2.5.rb
+++ b/Formula/dart@2.5.rb
@@ -35,7 +35,7 @@ class DartAT25 < Formula
   def install
     libexec.install Dir["*"]
     bin.install_symlink "#{libexec}/bin/dart"
-    bin.write_exec_script Dir["#{libexec}/bin/{pub,dart?*}"]
+    bin.write_exec_script Dir["#{libexec}/bin/{pub,dart?*}"].select { |f| File.executable?(f) }
   end
 
   def shim_script(target)

--- a/Formula/dart@2.6.rb
+++ b/Formula/dart@2.6.rb
@@ -35,7 +35,7 @@ class DartAT26 < Formula
   def install
     libexec.install Dir["*"]
     bin.install_symlink "#{libexec}/bin/dart"
-    bin.write_exec_script Dir["#{libexec}/bin/{pub,dart?*}"]
+    bin.write_exec_script Dir["#{libexec}/bin/{pub,dart?*}"].select { |f| File.executable?(f) }
   end
 
   def shim_script(target)

--- a/Formula/dart@2.7.rb
+++ b/Formula/dart@2.7.rb
@@ -35,7 +35,7 @@ class DartAT27 < Formula
   def install
     libexec.install Dir["*"]
     bin.install_symlink "#{libexec}/bin/dart"
-    bin.write_exec_script Dir["#{libexec}/bin/{pub,dart?*}"]
+    bin.write_exec_script Dir["#{libexec}/bin/{pub,dart?*}"].select { |f| File.executable?(f) }
   end
 
   def shim_script(target)

--- a/Formula/dart@2.8.rb
+++ b/Formula/dart@2.8.rb
@@ -30,7 +30,7 @@ class DartAT28 < Formula
   def install
     libexec.install Dir["*"]
     bin.install_symlink "#{libexec}/bin/dart"
-    bin.write_exec_script Dir["#{libexec}/bin/{pub,dart?*}"]
+    bin.write_exec_script Dir["#{libexec}/bin/{pub,dart?*}"].select { |f| File.executable?(f) }
   end
 
   def shim_script(target)

--- a/Formula/dart@2.9.rb
+++ b/Formula/dart@2.9.rb
@@ -30,7 +30,7 @@ class DartAT29 < Formula
   def install
     libexec.install Dir["*"]
     bin.install_symlink "#{libexec}/bin/dart"
-    bin.write_exec_script Dir["#{libexec}/bin/{pub,dart?*}"]
+    bin.write_exec_script Dir["#{libexec}/bin/{pub,dart?*}"].select { |f| File.executable?(f) }
   end
 
   def shim_script(target)

--- a/Formula/dart@3.0.0.rb
+++ b/Formula/dart@3.0.0.rb
@@ -33,7 +33,7 @@ class DartAT300 < Formula
   def install
     libexec.install Dir["*"]
     bin.install_symlink "#{libexec}/bin/dart"
-    bin.write_exec_script Dir["#{libexec}/bin/{pub,dart?*}"]
+    bin.write_exec_script Dir["#{libexec}/bin/{pub,dart?*}"].select { |f| File.executable?(f) }
   end
 
   def caveats

--- a/Formula/dart@3.0.1.rb
+++ b/Formula/dart@3.0.1.rb
@@ -33,7 +33,7 @@ class DartAT301 < Formula
   def install
     libexec.install Dir["*"]
     bin.install_symlink "#{libexec}/bin/dart"
-    bin.write_exec_script Dir["#{libexec}/bin/{pub,dart?*}"]
+    bin.write_exec_script Dir["#{libexec}/bin/{pub,dart?*}"].select { |f| File.executable?(f) }
   end
 
   def caveats

--- a/Formula/dart@3.0.2.rb
+++ b/Formula/dart@3.0.2.rb
@@ -33,7 +33,7 @@ class DartAT302 < Formula
   def install
     libexec.install Dir["*"]
     bin.install_symlink "#{libexec}/bin/dart"
-    bin.write_exec_script Dir["#{libexec}/bin/{pub,dart?*}"]
+    bin.write_exec_script Dir["#{libexec}/bin/{pub,dart?*}"].select { |f| File.executable?(f) }
   end
 
   def caveats

--- a/Formula/dart@3.0.3.rb
+++ b/Formula/dart@3.0.3.rb
@@ -33,7 +33,7 @@ class DartAT303 < Formula
   def install
     libexec.install Dir["*"]
     bin.install_symlink "#{libexec}/bin/dart"
-    bin.write_exec_script Dir["#{libexec}/bin/{pub,dart?*}"]
+    bin.write_exec_script Dir["#{libexec}/bin/{pub,dart?*}"].select { |f| File.executable?(f) }
   end
 
   def caveats

--- a/Formula/dart@3.0.4.rb
+++ b/Formula/dart@3.0.4.rb
@@ -33,7 +33,7 @@ class DartAT304 < Formula
   def install
     libexec.install Dir["*"]
     bin.install_symlink "#{libexec}/bin/dart"
-    bin.write_exec_script Dir["#{libexec}/bin/{pub,dart?*}"]
+    bin.write_exec_script Dir["#{libexec}/bin/{pub,dart?*}"].select { |f| File.executable?(f) }
   end
 
   def caveats

--- a/Formula/dart@3.0.5.rb
+++ b/Formula/dart@3.0.5.rb
@@ -33,7 +33,7 @@ class DartAT305 < Formula
   def install
     libexec.install Dir["*"]
     bin.install_symlink "#{libexec}/bin/dart"
-    bin.write_exec_script Dir["#{libexec}/bin/{pub,dart?*}"]
+    bin.write_exec_script Dir["#{libexec}/bin/{pub,dart?*}"].select { |f| File.executable?(f) }
   end
 
   def caveats

--- a/Formula/dart@3.0.6.rb
+++ b/Formula/dart@3.0.6.rb
@@ -33,7 +33,7 @@ class DartAT306 < Formula
   def install
     libexec.install Dir["*"]
     bin.install_symlink "#{libexec}/bin/dart"
-    bin.write_exec_script Dir["#{libexec}/bin/{pub,dart?*}"]
+    bin.write_exec_script Dir["#{libexec}/bin/{pub,dart?*}"].select { |f| File.executable?(f) }
   end
 
   def caveats

--- a/Formula/dart@3.0.7.rb
+++ b/Formula/dart@3.0.7.rb
@@ -33,7 +33,7 @@ class DartAT307 < Formula
   def install
     libexec.install Dir["*"]
     bin.install_symlink "#{libexec}/bin/dart"
-    bin.write_exec_script Dir["#{libexec}/bin/{pub,dart?*}"]
+    bin.write_exec_script Dir["#{libexec}/bin/{pub,dart?*}"].select { |f| File.executable?(f) }
   end
 
   def caveats

--- a/Formula/dart@3.1.0.rb
+++ b/Formula/dart@3.1.0.rb
@@ -33,7 +33,7 @@ class DartAT310 < Formula
   def install
     libexec.install Dir["*"]
     bin.install_symlink "#{libexec}/bin/dart"
-    bin.write_exec_script Dir["#{libexec}/bin/{pub,dart?*}"]
+    bin.write_exec_script Dir["#{libexec}/bin/{pub,dart?*}"].select { |f| File.executable?(f) }
   end
 
   def caveats

--- a/Formula/dart@3.1.1.rb
+++ b/Formula/dart@3.1.1.rb
@@ -33,7 +33,7 @@ class DartAT311 < Formula
   def install
     libexec.install Dir["*"]
     bin.install_symlink "#{libexec}/bin/dart"
-    bin.write_exec_script Dir["#{libexec}/bin/{pub,dart?*}"]
+    bin.write_exec_script Dir["#{libexec}/bin/{pub,dart?*}"].select { |f| File.executable?(f) }
   end
 
   def caveats

--- a/Formula/dart@3.1.2.rb
+++ b/Formula/dart@3.1.2.rb
@@ -33,7 +33,7 @@ class DartAT312 < Formula
   def install
     libexec.install Dir["*"]
     bin.install_symlink "#{libexec}/bin/dart"
-    bin.write_exec_script Dir["#{libexec}/bin/{pub,dart?*}"]
+    bin.write_exec_script Dir["#{libexec}/bin/{pub,dart?*}"].select { |f| File.executable?(f) }
   end
 
   def caveats

--- a/Formula/dart@3.1.3.rb
+++ b/Formula/dart@3.1.3.rb
@@ -33,7 +33,7 @@ class DartAT313 < Formula
   def install
     libexec.install Dir["*"]
     bin.install_symlink "#{libexec}/bin/dart"
-    bin.write_exec_script Dir["#{libexec}/bin/{pub,dart?*}"]
+    bin.write_exec_script Dir["#{libexec}/bin/{pub,dart?*}"].select { |f| File.executable?(f) }
   end
 
   def caveats

--- a/Formula/dart@3.1.4.rb
+++ b/Formula/dart@3.1.4.rb
@@ -33,7 +33,7 @@ class DartAT314 < Formula
   def install
     libexec.install Dir["*"]
     bin.install_symlink "#{libexec}/bin/dart"
-    bin.write_exec_script Dir["#{libexec}/bin/{pub,dart?*}"]
+    bin.write_exec_script Dir["#{libexec}/bin/{pub,dart?*}"].select { |f| File.executable?(f) }
   end
 
   def caveats

--- a/Formula/dart@3.1.5.rb
+++ b/Formula/dart@3.1.5.rb
@@ -33,7 +33,7 @@ class DartAT315 < Formula
   def install
     libexec.install Dir["*"]
     bin.install_symlink "#{libexec}/bin/dart"
-    bin.write_exec_script Dir["#{libexec}/bin/{pub,dart?*}"]
+    bin.write_exec_script Dir["#{libexec}/bin/{pub,dart?*}"].select { |f| File.executable?(f) }
   end
 
   def caveats

--- a/Formula/dart@3.2.0.rb
+++ b/Formula/dart@3.2.0.rb
@@ -33,7 +33,7 @@ class DartAT320 < Formula
   def install
     libexec.install Dir["*"]
     bin.install_symlink "#{libexec}/bin/dart"
-    bin.write_exec_script Dir["#{libexec}/bin/{pub,dart?*}"]
+    bin.write_exec_script Dir["#{libexec}/bin/{pub,dart?*}"].select { |f| File.executable?(f) }
   end
 
   def caveats

--- a/Formula/dart@3.2.1.rb
+++ b/Formula/dart@3.2.1.rb
@@ -33,7 +33,7 @@ class DartAT321 < Formula
   def install
     libexec.install Dir["*"]
     bin.install_symlink "#{libexec}/bin/dart"
-    bin.write_exec_script Dir["#{libexec}/bin/{pub,dart?*}"]
+    bin.write_exec_script Dir["#{libexec}/bin/{pub,dart?*}"].select { |f| File.executable?(f) }
   end
 
   def caveats

--- a/Formula/dart@3.2.2.rb
+++ b/Formula/dart@3.2.2.rb
@@ -33,7 +33,7 @@ class DartAT322 < Formula
   def install
     libexec.install Dir["*"]
     bin.install_symlink "#{libexec}/bin/dart"
-    bin.write_exec_script Dir["#{libexec}/bin/{pub,dart?*}"]
+    bin.write_exec_script Dir["#{libexec}/bin/{pub,dart?*}"].select { |f| File.executable?(f) }
   end
 
   def caveats

--- a/Formula/dart@3.2.3.rb
+++ b/Formula/dart@3.2.3.rb
@@ -33,7 +33,7 @@ class DartAT323 < Formula
   def install
     libexec.install Dir["*"]
     bin.install_symlink "#{libexec}/bin/dart"
-    bin.write_exec_script Dir["#{libexec}/bin/{pub,dart?*}"]
+    bin.write_exec_script Dir["#{libexec}/bin/{pub,dart?*}"].select { |f| File.executable?(f) }
   end
 
   def caveats

--- a/Formula/dart@3.2.4.rb
+++ b/Formula/dart@3.2.4.rb
@@ -33,7 +33,7 @@ class DartAT324 < Formula
   def install
     libexec.install Dir["*"]
     bin.install_symlink "#{libexec}/bin/dart"
-    bin.write_exec_script Dir["#{libexec}/bin/{pub,dart?*}"]
+    bin.write_exec_script Dir["#{libexec}/bin/{pub,dart?*}"].select { |f| File.executable?(f) }
   end
 
   def caveats

--- a/Formula/dart@3.2.5.rb
+++ b/Formula/dart@3.2.5.rb
@@ -33,7 +33,7 @@ class DartAT325 < Formula
   def install
     libexec.install Dir["*"]
     bin.install_symlink "#{libexec}/bin/dart"
-    bin.write_exec_script Dir["#{libexec}/bin/{pub,dart?*}"]
+    bin.write_exec_script Dir["#{libexec}/bin/{pub,dart?*}"].select { |f| File.executable?(f) }
   end
 
   def caveats

--- a/Formula/dart@3.2.6.rb
+++ b/Formula/dart@3.2.6.rb
@@ -33,7 +33,7 @@ class DartAT326 < Formula
   def install
     libexec.install Dir["*"]
     bin.install_symlink "#{libexec}/bin/dart"
-    bin.write_exec_script Dir["#{libexec}/bin/{pub,dart?*}"]
+    bin.write_exec_script Dir["#{libexec}/bin/{pub,dart?*}"].select { |f| File.executable?(f) }
   end
 
   def caveats

--- a/Formula/dart@3.3.0.rb
+++ b/Formula/dart@3.3.0.rb
@@ -33,7 +33,7 @@ class DartAT330 < Formula
   def install
     libexec.install Dir["*"]
     bin.install_symlink "#{libexec}/bin/dart"
-    bin.write_exec_script Dir["#{libexec}/bin/{pub,dart?*}"]
+    bin.write_exec_script Dir["#{libexec}/bin/{pub,dart?*}"].select { |f| File.executable?(f) }
   end
 
   def caveats

--- a/Formula/dart@3.3.1.rb
+++ b/Formula/dart@3.3.1.rb
@@ -33,7 +33,7 @@ class DartAT331 < Formula
   def install
     libexec.install Dir["*"]
     bin.install_symlink "#{libexec}/bin/dart"
-    bin.write_exec_script Dir["#{libexec}/bin/{pub,dart?*}"]
+    bin.write_exec_script Dir["#{libexec}/bin/{pub,dart?*}"].select { |f| File.executable?(f) }
   end
 
   def caveats

--- a/Formula/dart@3.3.2.rb
+++ b/Formula/dart@3.3.2.rb
@@ -33,7 +33,7 @@ class DartAT332 < Formula
   def install
     libexec.install Dir["*"]
     bin.install_symlink "#{libexec}/bin/dart"
-    bin.write_exec_script Dir["#{libexec}/bin/{pub,dart?*}"]
+    bin.write_exec_script Dir["#{libexec}/bin/{pub,dart?*}"].select { |f| File.executable?(f) }
   end
 
   def caveats

--- a/Formula/dart@3.3.3.rb
+++ b/Formula/dart@3.3.3.rb
@@ -33,7 +33,7 @@ class DartAT333 < Formula
   def install
     libexec.install Dir["*"]
     bin.install_symlink "#{libexec}/bin/dart"
-    bin.write_exec_script Dir["#{libexec}/bin/{pub,dart?*}"]
+    bin.write_exec_script Dir["#{libexec}/bin/{pub,dart?*}"].select { |f| File.executable?(f) }
   end
 
   def caveats

--- a/Formula/dart@3.3.4.rb
+++ b/Formula/dart@3.3.4.rb
@@ -33,7 +33,7 @@ class DartAT334 < Formula
   def install
     libexec.install Dir["*"]
     bin.install_symlink "#{libexec}/bin/dart"
-    bin.write_exec_script Dir["#{libexec}/bin/{pub,dart?*}"]
+    bin.write_exec_script Dir["#{libexec}/bin/{pub,dart?*}"].select { |f| File.executable?(f) }
   end
 
   def caveats

--- a/Formula/dart@3.4.0.rb
+++ b/Formula/dart@3.4.0.rb
@@ -33,7 +33,7 @@ class DartAT340 < Formula
   def install
     libexec.install Dir["*"]
     bin.install_symlink "#{libexec}/bin/dart"
-    bin.write_exec_script Dir["#{libexec}/bin/{pub,dart?*}"]
+    bin.write_exec_script Dir["#{libexec}/bin/{pub,dart?*}"].select { |f| File.executable?(f) }
   end
 
   def caveats

--- a/Formula/dart@3.4.1.rb
+++ b/Formula/dart@3.4.1.rb
@@ -33,7 +33,7 @@ class DartAT341 < Formula
   def install
     libexec.install Dir["*"]
     bin.install_symlink "#{libexec}/bin/dart"
-    bin.write_exec_script Dir["#{libexec}/bin/{pub,dart?*}"]
+    bin.write_exec_script Dir["#{libexec}/bin/{pub,dart?*}"].select { |f| File.executable?(f) }
   end
 
   def caveats

--- a/Formula/dart@3.4.2.rb
+++ b/Formula/dart@3.4.2.rb
@@ -33,7 +33,7 @@ class DartAT342 < Formula
   def install
     libexec.install Dir["*"]
     bin.install_symlink "#{libexec}/bin/dart"
-    bin.write_exec_script Dir["#{libexec}/bin/{pub,dart?*}"]
+    bin.write_exec_script Dir["#{libexec}/bin/{pub,dart?*}"].select { |f| File.executable?(f) }
   end
 
   def caveats

--- a/Formula/dart@3.4.3.rb
+++ b/Formula/dart@3.4.3.rb
@@ -33,7 +33,7 @@ class DartAT343 < Formula
   def install
     libexec.install Dir["*"]
     bin.install_symlink "#{libexec}/bin/dart"
-    bin.write_exec_script Dir["#{libexec}/bin/{pub,dart?*}"]
+    bin.write_exec_script Dir["#{libexec}/bin/{pub,dart?*}"].select { |f| File.executable?(f) }
   end
 
   def caveats

--- a/Formula/dart@3.4.4.rb
+++ b/Formula/dart@3.4.4.rb
@@ -33,7 +33,7 @@ class DartAT344 < Formula
   def install
     libexec.install Dir["*"]
     bin.install_symlink "#{libexec}/bin/dart"
-    bin.write_exec_script Dir["#{libexec}/bin/{pub,dart?*}"]
+    bin.write_exec_script Dir["#{libexec}/bin/{pub,dart?*}"].select { |f| File.executable?(f) }
   end
 
   def caveats

--- a/Formula/dart@3.5.0.rb
+++ b/Formula/dart@3.5.0.rb
@@ -33,7 +33,7 @@ class DartAT350 < Formula
   def install
     libexec.install Dir["*"]
     bin.install_symlink "#{libexec}/bin/dart"
-    bin.write_exec_script Dir["#{libexec}/bin/{pub,dart?*}"]
+    bin.write_exec_script Dir["#{libexec}/bin/{pub,dart?*}"].select { |f| File.executable?(f) }
   end
 
   def caveats

--- a/Formula/dart@3.5.1.rb
+++ b/Formula/dart@3.5.1.rb
@@ -33,7 +33,7 @@ class DartAT351 < Formula
   def install
     libexec.install Dir["*"]
     bin.install_symlink "#{libexec}/bin/dart"
-    bin.write_exec_script Dir["#{libexec}/bin/{pub,dart?*}"]
+    bin.write_exec_script Dir["#{libexec}/bin/{pub,dart?*}"].select { |f| File.executable?(f) }
   end
 
   def caveats

--- a/Formula/dart@3.5.2.rb
+++ b/Formula/dart@3.5.2.rb
@@ -33,7 +33,7 @@ class DartAT352 < Formula
   def install
     libexec.install Dir["*"]
     bin.install_symlink "#{libexec}/bin/dart"
-    bin.write_exec_script Dir["#{libexec}/bin/{pub,dart?*}"]
+    bin.write_exec_script Dir["#{libexec}/bin/{pub,dart?*}"].select { |f| File.executable?(f) }
   end
 
   def caveats

--- a/Formula/dart@3.5.3.rb
+++ b/Formula/dart@3.5.3.rb
@@ -33,7 +33,7 @@ class DartAT353 < Formula
   def install
     libexec.install Dir["*"]
     bin.install_symlink "#{libexec}/bin/dart"
-    bin.write_exec_script Dir["#{libexec}/bin/{pub,dart?*}"]
+    bin.write_exec_script Dir["#{libexec}/bin/{pub,dart?*}"].select { |f| File.executable?(f) }
   end
 
   def caveats

--- a/Formula/dart@3.5.4.rb
+++ b/Formula/dart@3.5.4.rb
@@ -33,7 +33,7 @@ class DartAT354 < Formula
   def install
     libexec.install Dir["*"]
     bin.install_symlink "#{libexec}/bin/dart"
-    bin.write_exec_script Dir["#{libexec}/bin/{pub,dart?*}"]
+    bin.write_exec_script Dir["#{libexec}/bin/{pub,dart?*}"].select { |f| File.executable?(f) }
   end
 
   def caveats

--- a/Formula/dart@3.6.0.rb
+++ b/Formula/dart@3.6.0.rb
@@ -33,7 +33,7 @@ class DartAT360 < Formula
   def install
     libexec.install Dir["*"]
     bin.install_symlink "#{libexec}/bin/dart"
-    bin.write_exec_script Dir["#{libexec}/bin/{pub,dart?*}"]
+    bin.write_exec_script Dir["#{libexec}/bin/{pub,dart?*}"].select { |f| File.executable?(f) }
   end
 
   def caveats

--- a/Formula/dart@3.6.1.rb
+++ b/Formula/dart@3.6.1.rb
@@ -33,7 +33,7 @@ class DartAT361 < Formula
   def install
     libexec.install Dir["*"]
     bin.install_symlink "#{libexec}/bin/dart"
-    bin.write_exec_script Dir["#{libexec}/bin/{pub,dart?*}"]
+    bin.write_exec_script Dir["#{libexec}/bin/{pub,dart?*}"].select { |f| File.executable?(f) }
   end
 
   def caveats

--- a/Formula/dart@3.6.2.rb
+++ b/Formula/dart@3.6.2.rb
@@ -33,7 +33,7 @@ class DartAT362 < Formula
   def install
     libexec.install Dir["*"]
     bin.install_symlink "#{libexec}/bin/dart"
-    bin.write_exec_script Dir["#{libexec}/bin/{pub,dart?*}"]
+    bin.write_exec_script Dir["#{libexec}/bin/{pub,dart?*}"].select { |f| File.executable?(f) }
   end
 
   def caveats

--- a/Formula/dart@3.7.0.rb
+++ b/Formula/dart@3.7.0.rb
@@ -33,7 +33,7 @@ class DartAT370 < Formula
   def install
     libexec.install Dir["*"]
     bin.install_symlink "#{libexec}/bin/dart"
-    bin.write_exec_script Dir["#{libexec}/bin/{pub,dart?*}"]
+    bin.write_exec_script Dir["#{libexec}/bin/{pub,dart?*}"].select { |f| File.executable?(f) }
   end
 
   def caveats

--- a/Formula/dart@3.7.1.rb
+++ b/Formula/dart@3.7.1.rb
@@ -33,7 +33,7 @@ class DartAT371 < Formula
   def install
     libexec.install Dir["*"]
     bin.install_symlink "#{libexec}/bin/dart"
-    bin.write_exec_script Dir["#{libexec}/bin/{pub,dart?*}"]
+    bin.write_exec_script Dir["#{libexec}/bin/{pub,dart?*}"].select { |f| File.executable?(f) }
   end
 
   def caveats

--- a/Formula/dart@3.7.2.rb
+++ b/Formula/dart@3.7.2.rb
@@ -33,7 +33,7 @@ class DartAT372 < Formula
   def install
     libexec.install Dir["*"]
     bin.install_symlink "#{libexec}/bin/dart"
-    bin.write_exec_script Dir["#{libexec}/bin/{pub,dart?*}"]
+    bin.write_exec_script Dir["#{libexec}/bin/{pub,dart?*}"].select { |f| File.executable?(f) }
   end
 
   def caveats

--- a/Formula/dart@3.7.3.rb
+++ b/Formula/dart@3.7.3.rb
@@ -33,7 +33,7 @@ class DartAT373 < Formula
   def install
     libexec.install Dir["*"]
     bin.install_symlink "#{libexec}/bin/dart"
-    bin.write_exec_script Dir["#{libexec}/bin/{pub,dart?*}"]
+    bin.write_exec_script Dir["#{libexec}/bin/{pub,dart?*}"].select { |f| File.executable?(f) }
   end
 
   def caveats

--- a/Formula/dart@3.8.0.rb
+++ b/Formula/dart@3.8.0.rb
@@ -33,7 +33,7 @@ class DartAT380 < Formula
   def install
     libexec.install Dir["*"]
     bin.install_symlink "#{libexec}/bin/dart"
-    bin.write_exec_script Dir["#{libexec}/bin/{pub,dart?*}"]
+    bin.write_exec_script Dir["#{libexec}/bin/{pub,dart?*}"].select { |f| File.executable?(f) }
   end
 
   def caveats

--- a/Formula/dart@3.8.1.rb
+++ b/Formula/dart@3.8.1.rb
@@ -28,7 +28,7 @@ class DartAT381 < Formula
   def install
     libexec.install Dir["*"]
     bin.install_symlink "#{libexec}/bin/dart"
-    bin.write_exec_script Dir["#{libexec}/bin/{pub,dart?*}"]
+    bin.write_exec_script Dir["#{libexec}/bin/{pub,dart?*}"].select { |f| File.executable?(f) }
   end
 
   def caveats

--- a/Formula/dart@3.8.2.rb
+++ b/Formula/dart@3.8.2.rb
@@ -28,7 +28,7 @@ class DartAT382 < Formula
   def install
     libexec.install Dir["*"]
     bin.install_symlink "#{libexec}/bin/dart"
-    bin.write_exec_script Dir["#{libexec}/bin/{pub,dart?*}"]
+    bin.write_exec_script Dir["#{libexec}/bin/{pub,dart?*}"].select { |f| File.executable?(f) }
   end
 
   def caveats

--- a/Formula/dart@3.8.3.rb
+++ b/Formula/dart@3.8.3.rb
@@ -28,7 +28,7 @@ class DartAT383 < Formula
   def install
     libexec.install Dir["*"]
     bin.install_symlink "#{libexec}/bin/dart"
-    bin.write_exec_script Dir["#{libexec}/bin/{pub,dart?*}"]
+    bin.write_exec_script Dir["#{libexec}/bin/{pub,dart?*}"].select { |f| File.executable?(f) }
   end
 
   def caveats

--- a/Formula/dart@3.9.0.rb
+++ b/Formula/dart@3.9.0.rb
@@ -28,7 +28,7 @@ class DartAT390 < Formula
   def install
     libexec.install Dir["*"]
     bin.install_symlink "#{libexec}/bin/dart"
-    bin.write_exec_script Dir["#{libexec}/bin/{pub,dart?*}"]
+    bin.write_exec_script Dir["#{libexec}/bin/{pub,dart?*}"].select { |f| File.executable?(f) }
   end
 
   def caveats

--- a/Formula/dart@3.9.1.rb
+++ b/Formula/dart@3.9.1.rb
@@ -28,7 +28,7 @@ class DartAT391 < Formula
   def install
     libexec.install Dir["*"]
     bin.install_symlink "#{libexec}/bin/dart"
-    bin.write_exec_script Dir["#{libexec}/bin/{pub,dart?*}"]
+    bin.write_exec_script Dir["#{libexec}/bin/{pub,dart?*}"].select { |f| File.executable?(f) }
   end
 
   def caveats


### PR DESCRIPTION
Currently dart-sdk ships with a `dart.sym` (or `dartvm.sym` in 3.10) file in bin folder, the homebrew formula here currently would create an executable shell wrapper for the non-executable `dart.sym`, causing it to incorrectly showing up in shell autocompletion.

```
$ cat /opt/homebrew/Cellar/dart/3.9.1/bin/dart.sym

#!/bin/bash
exec "/opt/homebrew/Cellar/dart/3.9.1/libexec/bin/dart.sym" "$@"
```

This PR fixes the bug by adding a filter to avoid creating exec script for non-executable files.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.