### PR TITLE
Fix GitHub Actions and README setup for Homebrew 6+ tap trust

### DIFF
--- a/.github/workflows/install-dart.yml
+++ b/.github/workflows/install-dart.yml
@@ -23,4 +23,6 @@ jobs:
 
       - run: brew tap dart-lang/dart
 
+      - run: brew trust dart-lang/dart
+
       - run: brew install dart

--- a/README.md
+++ b/README.md
@@ -8,10 +8,11 @@ Mac users can use these formulae to easily install and update Dart SDK. Both dev
 
 If you don't have homebrew, install it from their [homepage][homebrew].
 
-Then, add this tap:
+Then, add and trust this tap:
 
 ```
 brew tap "dart-lang/dart"
+brew trust "dart-lang/dart"
 ```
 
 ## Installing


### PR DESCRIPTION
Homebrew 6.0+ requires third-party taps to be explicitly trusted using `brew trust` before installing packages. This updates `.github/workflows/install-dart.yml` and `README.md` to include `brew trust dart-lang/dart` after `brew tap`.

Fixes #242
