### PR TITLE
Harden Dart SDK version expression

### DIFF
--- a/bin/update_homebrew.dart
+++ b/bin/update_homebrew.dart
@@ -104,6 +104,15 @@ Future<void> updateVersion(
   }
 }
 
+String _checkVersion(String version) {
+  if (!versionRegExp.hasMatch(version)) {
+    throw FormatException(
+      'Remote version string does not match ${versionRegExp.pattern}',
+    );
+  }
+  return version;
+}
+
 Future<String> getLatestVersion(String channel) async {
   final uri = Uri.parse(
     'https://storage.googleapis.com/'
@@ -111,14 +120,13 @@ Future<String> getLatestVersion(String channel) async {
   );
   final client = RetryClient(Client());
   try {
-    return jsonDecode(await client.read(uri))['version'];
+    return _checkVersion(jsonDecode(await client.read(uri))['version']);
   } finally {
     client.close();
   }
 }
 
 Future<List<String>> getVersions(String channel) async {
-  final versionRegExp = RegExp(r'\d+\.\d+.\d+(-.+)?');
   final uri = Uri.parse(
     'https://storage.googleapis.com/'
     'storage/v1/b/dart-archive/o?delimiter=%2F&alt=json&'

--- a/lib/src/formula.dart
+++ b/lib/src/formula.dart
@@ -2,6 +2,9 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+const versionPattern = r'\d+\.\d+\.\d+(-[\w.]+)?';
+final versionRegExp = RegExp('^$versionPattern\$');
+
 String updateFormula(
   String channel,
   String contents,
@@ -11,7 +14,7 @@ String updateFormula(
   // Replace the version identifier. Formulas with stable and pre-release
   // versions have multiple identifiers and only the right one should be
   // updated.
-  final versionId = RegExp(r'version \"\d+\.\d+.\d+(-[^"]+)?\" # ' + channel);
+  final versionId = RegExp('version "$versionPattern" # $channel');
   contents = contents.replaceAll(versionId, 'version "$version" # $channel');
 
   // Extract files and hashes that are stored in the formula in this format:

--- a/lib/update_homebrew.dart
+++ b/lib/update_homebrew.dart
@@ -12,6 +12,7 @@ import 'package:http/http.dart' as http;
 import 'package:path/path.dart' as p;
 
 import 'src/formula.dart';
+export 'src/formula.dart' show versionRegExp;
 
 part 'src/impl.dart';
 

--- a/test/update_homebrew_test.dart
+++ b/test/update_homebrew_test.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:test/test.dart';
+import 'package:update_homebrew/update_homebrew.dart';
 import '../bin/update_homebrew.dart' as bin;
 
 void main() {
@@ -12,5 +13,40 @@ void main() {
       '--revision=2.14.1',
       '--channel=stable',
     ]);
+  });
+
+  test('valid version validation', () {
+    final validVersions = [
+      '3.5.0',
+      '3.12.2',
+      '3.6.0-123.0.dev',
+      '3.13.0-167.1.beta',
+      '2.19.6',
+    ];
+    for (final version in validVersions) {
+      expect(
+        versionRegExp.hasMatch(version),
+        isTrue,
+        reason: 'Expected $version to be valid',
+      );
+    }
+  });
+
+  test('invalid version rejection', () {
+    final invalidVersions = [
+      '3.99.0 < Formula; end; system %(echo payload); class Z',
+      '3.99.0-x";system("echo payload");"',
+      '3.0X0',
+      '3.0.0\nputs "injection"',
+      'invalid/3.0.0/path',
+      '3.0.0; rm -rf /',
+    ];
+    for (final version in invalidVersions) {
+      expect(
+        versionRegExp.hasMatch(version),
+        isFalse,
+        reason: 'Expected $version to be rejected',
+      );
+    }
   });
 }


### PR DESCRIPTION
Harden regular expression matching for version strings by centralizing the regular expression definition and ensuring strict boundary matching.

References:
- b/528564193
- b/528564174

TAG=agy
CONV=5dc553e2-6338-4dc1-a7c4-baf65937e5e0