### PR TITLE
Trust dart-lang/dart tap in brew test-bot workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,6 +33,8 @@ jobs:
         if: steps.cache.outputs.cache-hit != 'true'
         run: brew install-bundler-gems
 
+      - run: brew trust dart-lang/dart
+
       - run: brew test-bot --only-cleanup-before
 
       - run: brew test-bot --only-setup


### PR DESCRIPTION
Homebrew 6+ requires third-party taps to be explicitly trusted.
Add `brew trust dart-lang/dart` to the brew test-bot workflow.

TAG=agy
