### PR TITLE
Restrict permissions for tests workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,6 +10,10 @@ on:
     paths:
       - '**.rb'
       - .github/workflows/tests.yml
+
+permissions:
+  contents: read
+
 jobs:
   test-bot:
     strategy:


### PR DESCRIPTION
Add permissions block with `contents: read` to satisfy security scans.

TAG=agy
CONV=54fd6513-42e9-4613-9840-e69f6966aadd
