### PR TITLE
Restrict permissions for test-package and install-dart workflows

### DIFF
--- a/.github/workflows/install-dart.yml
+++ b/.github/workflows/install-dart.yml
@@ -10,6 +10,10 @@ on:
     paths:
       - '**.rb'
       - .github/workflows/install-dart.yml
+
+permissions:
+  contents: read
+
 jobs:
   test-bot:
     strategy:

--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -9,6 +9,9 @@ on:
   schedule:
     - cron: "0 0 * * 0"
 
+permissions:
+  contents: read
+
 env:
   PUB_ENVIRONMENT: bot.github
 


### PR DESCRIPTION
Add permissions block with `contents: read` to satisfy security scans.

TAG=agy
CONV=e518d1b2-a1d5-4515-b216-3df3e36f1f10